### PR TITLE
SSO Cosmetic changes, profile specification message changes and additional tests.

### DIFF
--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -466,7 +466,7 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
         if self._original_profile_name:
             profile_name = self._original_profile_name
         else:
-            text = 'CLI profile name'
+            text = 'Profile name'
             default_profile = None
             if sso_account_id and sso_role_name:
                 default_profile = f'{sso_role_name}-{sso_account_id}'
@@ -478,7 +478,7 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
     def _prompt_for_cli_default_region(self):
         # TODO: figure out a way to get a list of reasonable client regions
         return self._prompt_for_profile_config(
-            'region', 'CLI default client Region')
+            'region', 'Default client Region')
 
     def _prompt_for_cli_output_format(self):
         return self._prompt_for_profile_config(
@@ -651,11 +651,18 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
 
     def _print_conclusion(self, configured_for_aws_credentials, profile_name):
         if configured_for_aws_credentials:
-            msg = (
-                '\nTo use this profile, specify the profile name using '
-                '--profile, as shown:\n\n'
-                'aws s3 ls --profile {}\n'
-            )
+            if profile_name.lower() == 'default':
+                msg = (
+                    '\nThe AWS CLI is now configured to use the default profile.\n'
+                    'To verify your identity, you can run:\n\n'
+                    'aws sts get-caller-identity\n'
+                )
+            else:
+                msg = (
+                    '\nTo use this profile, specify the profile name using '
+                    '--profile, as shown:\n\n'
+                    'aws sts get-caller-identity --profile {}\n'
+                )
         else:
             msg = 'Successfully configured SSO for profile: {}\n'
         uni_print(msg.format(profile_name))

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -674,7 +674,7 @@ class SessionWithDefaultPrompt(PromptWithDefault):
 @dataclasses.dataclass
 class RegionPrompt(PromptWithDefault):
     msg_format: str = dataclasses.field(
-        init=False, default="CLI default client Region [{default}]: "
+        init=False, default="Default client Region [{default}]: "
     )
 
 
@@ -688,7 +688,7 @@ class OutputPrompt(PromptWithDefault):
 @dataclasses.dataclass
 class ProfilePrompt(PromptWithDefault):
     msg_format: str = dataclasses.field(
-        init=False, default="CLI profile name [{default}]: "
+        init=False, default="Profile name [{default}]: "
     )
     expected_validator_cls: typing.Optional[Validator] = RequiredInputValidator
 
@@ -1513,6 +1513,37 @@ class TestConfigureSSOCommand:
             ],
         )
 
+class TestPrintConclusion:
+    def test_print_conclusion_default_profile_with_credentials(self, sso_cmd, capsys):
+        sso_cmd._print_conclusion(True, 'default')
+        captured = capsys.readouterr()
+        assert "The AWS CLI is now configured to use the default profile." in captured.out
+        assert "aws sts get-caller-identity" in captured.out
+
+    def test_print_conclusion_named_profile_with_credentials(self, sso_cmd, capsys):
+        profile_name = "test-profile"
+        sso_cmd._print_conclusion(True, profile_name)
+        captured = capsys.readouterr()
+        assert f"To use this profile, specify the profile name using --profile" in captured.out
+        assert f"aws sts get-caller-identity --profile {profile_name}" in captured.out
+
+    def test_print_conclusion_sso_configuration(self, sso_cmd, capsys):
+        profile_name = "test-profile"
+        sso_cmd._print_conclusion(False, profile_name)
+        captured = capsys.readouterr()
+        assert f"Successfully configured SSO for profile: {profile_name}" in captured.out
+
+    def test_print_conclusion_default_profile_case_insensitive(selfself, sso_cmd, capsys):
+        sso_cmd._print_conclusion(True, 'DEFAULT')
+        captured = capsys.readouterr()
+        assert "The AWS CLI is now configured to use the default profile." in captured.out
+        assert "aws sts get-caller-identity" in captured.out
+
+    def test_print_conclusion_empty_profile_name(self, sso_cmd, capsys):
+        sso_cmd._print_conclusion(True, '')
+        captured = capsys.readouterr()
+        assert "To use this profile, specify the profile name using --profile" in captured.out
+        assert "aws sts get-caller-identity --profile" in captured.out
 
 class TestConfigureSSOSessionCommand:
     def test_new_sso_session(


### PR DESCRIPTION
…on and profile name).

- Changed the example command output if they did configure a profile
- Introduced tests for changing the example command output when there is a configured user.
 - updated the missing tests accordingly (aws s3 ls --profile myProfile) in favor of "aws sts get-caller-identity".