### PR TITLE
Mark temporarily failing test as xfail

### DIFF
--- a/tests/backends/build_system/functional/test_lock_files.py
+++ b/tests/backends/build_system/functional/test_lock_files.py
@@ -144,6 +144,8 @@ def test_all_lock_files_are_generated_by_expected_python_version():
         "platforms we need to test are mac and Windows."
     ),
 )
+@pytest.mark.xfail(reason="pip-tools compatibility issue needs to be resolved:"
+                          " https://github.com/jazzband/pip-tools/issues/2252")
 def test_lock_files_are_up_to_date(tmpdir):
     reqs_dir = tmpdir / "requirements"
     reqs_dir.mkdir()


### PR DESCRIPTION
Description of changes: Temporarily marking failing `test_lock_files_are_up_to_date` test as xfail until pip-tools compatibility issue is resolved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Previous occurrence: 
- https://github.com/aws/aws-cli/pull/9563 resolved in https://github.com/aws/aws-cli/pull/9625