### PR TITLE
Fix double aws: [ERROR]: prefix on argparse validation errors

### DIFF
--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -14,7 +14,6 @@ import argparse
 import copy
 import sys
 from difflib import get_close_matches
-from awscli.errorformat import format_error_message
 
 HELP_BLURB = (
     "To see help text, you can run:\n"
@@ -114,8 +113,7 @@ class CLIArgParser(argparse.ArgumentParser):
         should raise an exception.
         """
         usage_message = self.format_usage()
-        error_message = format_error_message(message, prog=self.prog)
-        raise ArgParseException(f'{error_message}\n\n{usage_message}')
+        raise ArgParseException(f'{message}\n\n{usage_message}')
 
 
 class MainArgParser(CLIArgParser):


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Removed the `format_error_message()` call so the aws: [ERROR]: prefix is no longer baked into the `ArgParseException` message. The error handler chain already adds this prefix when displaying the error, which was causing it to appear twice fo argparse validation failures


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
