### PR TITLE
Prevent --query filter from being applied to structured erro…

### DIFF
--- a/awscli/errorhandler.py
+++ b/awscli/errorhandler.py
@@ -216,9 +216,8 @@ class FilteredExceptionHandler(BaseExceptionHandler):
                 EnhancedErrorFormatter().format_error(error_info, stderr)
                 return True
 
-            formatter_args = parsed_globals or argparse.Namespace(
-                query=None, color='auto'
-            )
+            color = getattr(parsed_globals, 'color', 'auto')
+            formatter_args = argparse.Namespace(query=None, color=color)
             formatter = get_formatter(error_format, formatter_args)
             formatter('error', error_info, stderr)
             return True


### PR DESCRIPTION
*Description of changes:* When structured error formatting was used, `parsed_globals` was passed directly to the formatter, which meant any --query expression would filter the error dict just like a normal API response. The fix always sets `query=None` for error output and preserves the user's --color preference.